### PR TITLE
232  Remove extra tags dropping after 1C export

### DIFF
--- a/etc/se-backup-restore.sh
+++ b/etc/se-backup-restore.sh
@@ -3,6 +3,16 @@
 sudo mkdir -p /opt/backup/shopelectro/
 sudo chown -R `whoami` /opt/
 
+# @todo #232 - DB restore error on local env.
+#  How to reproduce:
+#  - launch this script
+#  - restart se-python container
+#
+#  Traceback message:
+#  ```
+#  django.db.utils.OperationalError: FATAL:  could not open relation mapping file "global/pg_filenode.map": Permission denied
+#  ```
+
 for type in database media static
 do
     while true; do

--- a/shopelectro/management/commands/_update_catalog/utils.py
+++ b/shopelectro/management/commands/_update_catalog/utils.py
@@ -15,7 +15,8 @@ from django.conf import settings
 
 
 logger = logging.getLogger(__name__)
-Data = Dict[str, str]
+UUID_TYPE = str
+Data = Dict[str, Dict[str, dict]]
 NOT_SAVE_TEMPLATE = '{entity} with name="{name}" has no {field}. It\'ll not be' \
                     ' saved'
 

--- a/shopelectro/tests/tests_commands.py
+++ b/shopelectro/tests/tests_commands.py
@@ -125,26 +125,6 @@ class UpdateProducts(TestCase):
         self.assertEqual(updated_groups_count + create_count, TagGroup.objects.count())
         self.assertEqual(updated_tags_count + create_count, Tag.objects.count())
 
-    def test_delete_tags(self):
-        groups_count = 2
-
-        tag_data = {
-            str(group.uuid): {
-                'name': 'some name',
-                'tags': {
-                    tag.uuid: {'name': tag.name}
-                    for tag in Tag.objects.filter(group=group)
-                }
-            } for group in TagGroup.objects.all()[:groups_count]
-        }
-
-        tag_count = sum(len(data['tags']) for data in tag_data.values())
-
-        update_tags.delete(tag_data)
-
-        self.assertEqual(Tag.objects.count(), tag_count)
-        self.assertEqual(TagGroup.objects.count(), groups_count)
-
 
 class GeneratePrices(TestCase):
 


### PR DESCRIPTION
Closes #232 

Убрал в 1С-выгрузке снос тегов, что были в базе до выгрузки, но не были в файлах 1С
