### PR TITLE
232  Don't rewrite product.tags in export, but merge them

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -39,7 +39,7 @@ lint:
 deploy:
 	$(dcp) pull
 	$(dcp) stop
-	$(dcp) rm se-source
+	$(dcp) rm -f se-source
 	$(dcp) up -d
 	$(dcp) exec se-python python manage.py migrate
 	$(dcp) exec se-python python manage.py excel

--- a/docker/docker-compose-production.yml
+++ b/docker/docker-compose-production.yml
@@ -60,6 +60,7 @@ services:
     restart: always
     environment:
       - DJANGO_SETTINGS_MODULE=shopelectro.settings.dev
+      - DJANGO_LOG_LEVEL=$DJANGO_LOG_LEVEL
       - DATABASE_URL=postgres://$DB_USER:$DB_PASS@se-postgres/$DB_DEV_NAME
       - REDIS_PASSWORD=$REDIS_PASSWORD
       - REDIS_LOCATION_DEFAULT=redis://se-redis:6379/0

--- a/shopelectro/settings/base.py
+++ b/shopelectro/settings/base.py
@@ -181,6 +181,30 @@ LOGGING = {
             'handlers': ['console'],
             'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
         },
+        'pages': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+        },
+        'catalog': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+        },
+        'search': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+        },
+        'ecommerce': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+        },
+        'images': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+        },
+        'shopelectro': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+        },
     },
 }
 


### PR DESCRIPTION
Это нужно для того, чтобы теги, добавленные через Админку, не затирались при 1С-экспорте