### PR TITLE
#463  Pin celery version to `4.2.0` to fix celery deps error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
-celery==4.1.1
+celery==4.2.0
 Django==1.10
 django-debug-toolbar
 django-redis==4.8.0


### PR DESCRIPTION
#463 