### PR TITLE
#fix  Grade refarm to 0.5.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ sorl-thumbnail==12.5.0
 python-telegram-bot==11.1.0
 sentry-sdk==0.7.2
 https://github.com/selwin/django-user_agents/archive/master.zip
-https://github.com/fidals/refarm-site/archive/0.5.6.zip
+https://github.com/fidals/refarm-site/archive/0.5.7.zip


### PR DESCRIPTION
Update it to fix ga (google analytics) tracker problem:
https://sentry.fidals.com/fidals/shopelectro-front/issues/267/?query=is:unresolved