### PR TITLE
#fix  Rm backup docker service

### DIFF
--- a/docker/docker-compose-production.yml
+++ b/docker/docker-compose-production.yml
@@ -143,23 +143,6 @@ services:
     volumes:
       - /dev/shm:/dev/shm
 
-  # Контейнер делает бэкапы по крону.
-  # Бэкап - это несколько архивов: database.tar.gz, media.tar.gz, static.tar.gz
-  # в директории /opt/backup/shopelectro
-  backup-data:
-    build:
-      context: ..
-      dockerfile: docker/cron/Dockerfile
-    container_name: se-backup-data
-    environment:
-      - DAYS_TO_STORE=2
-    volumes_from:
-      - app
-    volumes:
-      - ../etc/backup/backup-entrypoint.sh:/usr/bin/entrypoint.sh
-      - ../etc/backup/crontab:/etc/cron.d/crontab
-      - /opt/backup/shopelectro:/opt/backup
-      - /opt/database/shopelectro:/usr/app/src/database
 
 networks:
   se-backend:


### PR DESCRIPTION
Current backup system takes too much disk space on serv.
Our files and DB are not changed too frequently. So it should do incremental backups instead of the full ones every time.

Mentioned incremental backups idea at the https://github.com/fidals/stroyprombeton/issues/188
We'll implement them with this task or it's subtask